### PR TITLE
Disable Dark Reader explicitly as the site already has a dark theme

### DIFF
--- a/website/src/.vitepress/config/headConfig.ts
+++ b/website/src/.vitepress/config/headConfig.ts
@@ -1,6 +1,8 @@
 import type { HeadConfig } from "vitepress";
 
 const headConfig: HeadConfig[] = [
+	["meta", { name: "darkreader-lock" }],
+
 	["meta", { name: "theme-color", content: "#818CF8" }],
 	["meta", { name: "msapplication-TileColor", content: "#818CF8" }],
 


### PR DESCRIPTION
Some users (like me) uses the Dark Reader extension on browsers to force a dark theme. As the site already has an automatic theme and support for both light and dark, doesn't need to be enabled in the browser extension.

Reference: https://github.com/darkreader/darkreader/blob/main/CONTRIBUTING.md#disabling-dark-reader-on-your-site