### PR TITLE
Show sidebar on the download and extension pages

### DIFF
--- a/website/src/.vitepress/config/navigation/sidebar.ts
+++ b/website/src/.vitepress/config/navigation/sidebar.ts
@@ -1,6 +1,8 @@
 import { getSidebar } from "vitepress-plugin-auto-sidebar";
 
 const sidebar = {
+	"/download/": defaultSidebar(),
+	"/extensions/": defaultSidebar(),
 	"/docs/": defaultSidebar(),
 	"/forks/": defaultSidebar(),
 	"/changelogs/": defaultSidebar(),

--- a/website/src/.vitepress/theme/components/Extensions/ExtensionItem.vue
+++ b/website/src/.vitepress/theme/components/Extensions/ExtensionItem.vue
@@ -143,6 +143,10 @@ export default {
 		border-radius: 8px
 		padding: 0.5em
 
+		.extension-icon {
+			margin-left: 0;
+		}
+
 		.extension-download {
 			margin-right: 0
 		}

--- a/website/src/download/index.md
+++ b/website/src/download/index.md
@@ -1,7 +1,6 @@
 ---
 title: Download
 description: Download page that allows users to access and install the latest version of the app.
-aside: false
 lastUpdated: false
 editLink: false
 prev: false

--- a/website/src/extensions/index.md
+++ b/website/src/extensions/index.md
@@ -1,7 +1,6 @@
 ---
 title: Extensions
 description: Browse and install the full list of sources for Tachiyomi.
-aside: false
 lastUpdated: false
 editLink: false
 prev: false


### PR DESCRIPTION
Currently, the aside space is empty, but we can think about something to fill it later. The page content is centered as it was before but give the users the ability to navigate more easily, specially in mobile devices.