### PR TITLE
Update the navbar app version on build

### DIFF
--- a/website/src/.vitepress/config.ts
+++ b/website/src/.vitepress/config.ts
@@ -1,3 +1,4 @@
+import { URL, fileURLToPath } from "node:url";
 import { defineConfig, loadEnv } from "vitepress";
 
 import markdownConfig from "./config/markdownConfig"; // For use with loading Markdown plugins
@@ -30,4 +31,17 @@ export default defineConfig({
 		generateFeed(context, hostname);
 		generateOgImages(context);
 	},
+	vite: {
+		resolve: {
+			alias: [
+				{
+					// Used to show the release version on navbar.
+					find: /^.*\/VPNavBarMenu\.vue$/,
+					replacement: fileURLToPath(
+						new URL("./theme/components/CustomNavBarMenu.vue", import.meta.url)
+					),
+				},
+			]
+		}
+	}
 });

--- a/website/src/.vitepress/config.ts
+++ b/website/src/.vitepress/config.ts
@@ -41,6 +41,12 @@ export default defineConfig({
 						new URL("./theme/components/CustomNavBarMenu.vue", import.meta.url)
 					),
 				},
+				{
+					find: /^.*VPNavScreenMenu\.vue$/,
+					replacement: fileURLToPath(
+						new URL("./theme/components/CustomNavScreenMenu.vue", import.meta.url)
+					),
+				},
 			]
 		}
 	}

--- a/website/src/.vitepress/config/navigation/navbar.ts
+++ b/website/src/.vitepress/config/navigation/navbar.ts
@@ -1,13 +1,13 @@
-const APP_VERSION = "0.14.6";
+import type { DefaultTheme } from "vitepress";
 
-const nav = [
+const nav: DefaultTheme.NavItem[] = [
 	{
 		text: "Documentation",
 		link: "/docs/guides/getting-started",
 		activeMatch: "/docs/",
 	},
 	{
-		text: APP_VERSION,
+		text: "{app_version}",
 		activeMatch: "^/*?(download|changelogs)/*?$",
 		items: [
 			{
@@ -16,7 +16,7 @@ const nav = [
 			},
 			{
 				text: "Changelog",
-				link: `/changelogs/#v${APP_VERSION}`,
+				link: "/changelogs/#v{app_version}",
 			},
 			{
 				text: "Contributing",

--- a/website/src/.vitepress/theme/components/CustomNavBarMenu.vue
+++ b/website/src/.vitepress/theme/components/CustomNavBarMenu.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { type DefaultTheme, useData } from "vitepress";
+
+import { data as release } from "../data/release.data";
+
+import VPNavBarMenuLink from "vitepress/dist/client/theme-default/components/VPNavBarMenuLink.vue";
+import VPNavBarMenuGroup from "vitepress/dist/client/theme-default/components/VPNavBarMenuGroup.vue";
+
+const { theme } = useData<DefaultTheme.Config>();
+
+/**
+ * Workaround to use the release data directly while the sidebar
+ * and navbar doesn't support using the VitePress data loading.
+ */
+const nav = computed(() => {
+	return theme.value.nav?.map((item) => {
+		if (item.text !== "{app_version}") {
+			return item
+		}
+
+		const appVersion = release.stable.tag_name.substring(1);
+
+		return <DefaultTheme.NavItemWithChildren> {
+			...item,
+			text: item.text === "{app_version}"	? appVersion : item.text,
+			items: (item as DefaultTheme.NavItemWithChildren).items.map((child) => {
+				if (!("link" in child)) {
+					return child;
+				}
+
+				return <DefaultTheme.NavItemWithLink> {
+					...child,
+					link: child.link.replace("{app_version}", appVersion),
+				}
+			}),
+		}
+	});
+})
+</script>
+
+<template>
+	<nav v-if="nav" aria-labelledby="main-nav-aria-label" class="VPNavBarMenu">
+		<span id="main-nav-aria-label" class="visually-hidden">Main Navigation</span>
+		<template v-for="item in nav" :key="item.text">
+			<VPNavBarMenuLink v-if="'link' in item" :item="item" />
+			<VPNavBarMenuGroup v-else :item="item" />
+		</template>
+	</nav>
+</template>
+
+<style lang="stylus" scoped>
+.VPNavBarMenu {
+	display: none
+}
+
+@media (min-width: 768px) {
+	.VPNavBarMenu {
+		display: flex
+	}
+}
+</style>

--- a/website/src/.vitepress/theme/components/CustomNavScreenMenu.vue
+++ b/website/src/.vitepress/theme/components/CustomNavScreenMenu.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { type DefaultTheme, useData } from "vitepress";
+
+import { data as release } from "../data/release.data";
+
+import VPNavScreenMenuLink from "vitepress/dist/client/theme-default/components/VPNavScreenMenuLink.vue";
+import VPNavScreenMenuGroup from "vitepress/dist/client/theme-default/components/VPNavScreenMenuGroup.vue";
+
+const { theme } = useData<DefaultTheme.Config>();
+
+/**
+ * Workaround to use the release data directly while the sidebar
+ * and navbar doesn't support using the VitePress data loading.
+ */
+const nav = computed(() => {
+	return theme.value.nav?.map((item) => {
+		if (item.text !== "{app_version}") {
+			return item
+		}
+
+		const appVersion = release.stable.tag_name.substring(1);
+
+		return <DefaultTheme.NavItemWithChildren> {
+			...item,
+			text: item.text === "{app_version}"	? appVersion : item.text,
+			items: (item as DefaultTheme.NavItemWithChildren).items.map((child) => {
+				if (!("link" in child)) {
+					return child;
+				}
+
+				return <DefaultTheme.NavItemWithLink> {
+					...child,
+					link: child.link.replace("{app_version}", appVersion),
+				}
+			}),
+		}
+	});
+})
+</script>
+
+<template>
+	<nav v-if="nav" class="VPNavScreenMenu">
+		<template v-for="item in nav" :key="item.text">
+		<VPNavScreenMenuLink
+			v-if="'link' in item"
+			:item="item"
+		/>
+		<VPNavScreenMenuGroup
+			v-else
+			:text="item.text || ''"
+			:items="item.items"
+		/>
+		</template>
+	</nav>
+</template>


### PR DESCRIPTION
Adds a custom `VPNavBarMenu` and `VPNavScreenMenu` component replacement that can access the release data.

As the [documentation](https://vitepress.dev/guide/extending-default-theme#overriding-internal-components) states:

> Since the components are internal, there is a slight chance their name is updated between minor releases.

So need to keep checking in case VitePress change the theme.

Closes #9.