### PR TITLE
Revert VitePress update to `v1.0.0-rc.11`

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -71,7 +71,7 @@
 		"stylus": "0.60.0",
 		"unplugin-element-plus": "0.8.0",
 		"vite-plugin-eslint": "1.8.1",
-		"vitepress": "1.0.0-rc.12",
+		"vitepress": "1.0.0-rc.11",
 		"vitepress-plugin-tabs": "0.3.0",
 		"vue": "3.3.4",
 		"vue-eslint-parser": "9.3.1",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -118,11 +118,11 @@ devDependencies:
     specifier: 1.8.1
     version: 1.8.1(eslint@8.49.0)(vite@4.4.9)
   vitepress:
-    specifier: 1.0.0-rc.12
-    version: 1.0.0-rc.12(@algolia/client-search@4.19.1)(@types/node@20.6.0)(axios@1.5.0)(search-insights@2.8.2)(stylus@0.60.0)
+    specifier: 1.0.0-rc.11
+    version: 1.0.0-rc.11(@algolia/client-search@4.19.1)(@types/node@20.6.0)(axios@1.5.0)(search-insights@2.8.2)(stylus@0.60.0)
   vitepress-plugin-tabs:
     specifier: 0.3.0
-    version: 0.3.0(vitepress@1.0.0-rc.12)(vue@3.3.4)
+    version: 0.3.0(vitepress@1.0.0-rc.11)(vue@3.3.4)
   vue:
     specifier: 3.3.4
     version: 3.3.4
@@ -5472,18 +5472,18 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitepress-plugin-tabs@0.3.0(vitepress@1.0.0-rc.12)(vue@3.3.4):
+  /vitepress-plugin-tabs@0.3.0(vitepress@1.0.0-rc.11)(vue@3.3.4):
     resolution: {integrity: sha512-3dKsBuP6PDzcFHgUtNCwwCs3bYoZduj7AcQkT9JfAKTRAKPCNmjiNInPT3IZ7AihL0SJNoQ3liz/e97z8oo+XA==}
     peerDependencies:
       vitepress: ^1.0.0-beta.2
       vue: ^3.3.4
     dependencies:
-      vitepress: 1.0.0-rc.12(@algolia/client-search@4.19.1)(@types/node@20.6.0)(axios@1.5.0)(search-insights@2.8.2)(stylus@0.60.0)
+      vitepress: 1.0.0-rc.11(@algolia/client-search@4.19.1)(@types/node@20.6.0)(axios@1.5.0)(search-insights@2.8.2)(stylus@0.60.0)
       vue: 3.3.4
     dev: true
 
-  /vitepress@1.0.0-rc.12(@algolia/client-search@4.19.1)(@types/node@20.6.0)(axios@1.5.0)(search-insights@2.8.2)(stylus@0.60.0):
-    resolution: {integrity: sha512-mZknN5l9lgbBjXwumwdOQQDM+gPivswFEykEQeenY0tv7eocS+bb801IpFZT3mFV6YRhSddmbutHlFgPPADjEg==}
+  /vitepress@1.0.0-rc.11(@algolia/client-search@4.19.1)(@types/node@20.6.0)(axios@1.5.0)(search-insights@2.8.2)(stylus@0.60.0):
+    resolution: {integrity: sha512-HUnfYOadqwLSahtgQxKt9/wiNHdd80BaUfQ+DIMpfq03Iv9CWX1SCBK4gxK/bMWns3Q0ArhXajQbU/fmBwYUMg==}
     hasBin: true
     dependencies:
       '@docsearch/css': 3.5.2


### PR DESCRIPTION
Related to vuejs/vitepress#2936.