### PR TITLE
Remove title header from the `news.json` file content

### DIFF
--- a/website/src/.vitepress/config/hooks/generateFeed.ts
+++ b/website/src/.vitepress/config/hooks/generateFeed.ts
@@ -38,7 +38,7 @@ async function generateFeed(config: SiteConfig, hostname: string) {
 		const markdown = (src ?? "")
 			.replace(/^---.*---/s, "")
 			.replace(/]\((\/.*?)\)/g, `](${hostname}$1)`)
-			.replace(/^#.*$/m, "")
+			.replace(/^# .*$/m, "")
 			.trim()
 
 		const post = {

--- a/website/src/.vitepress/config/hooks/generateFeed.ts
+++ b/website/src/.vitepress/config/hooks/generateFeed.ts
@@ -38,6 +38,7 @@ async function generateFeed(config: SiteConfig, hostname: string) {
 		const markdown = (src ?? "")
 			.replace(/^---.*---/s, "")
 			.replace(/]\((\/.*?)\)/g, `](${hostname}$1)`)
+			.replace(/^#.*$/m, "")
 			.trim()
 
 		const post = {


### PR DESCRIPTION
The first `h1` which is the same as the title doesn't need to be inside the content as usually it would be rendered separately in any app that consumes the JSON.